### PR TITLE
Fix to work with paths including space characters

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ function format(document: TextDocument): Promise<TextEdit[]> {
   return new Promise((resolve, reject) => {
     // Create mix command
     const mixFormatArgs: string = workspace.getConfiguration("elixir.formatter").get("mixFormatArgs") || "";
-    const cmd = `mix format ${mixFormatArgs} ${document.fileName}`;
+    const cmd = `mix format ${mixFormatArgs} "${document.fileName}"`;
 
     // Figure out the working directory to run mix format in
     const workspaceRootPath = workspace.rootPath ? workspace.rootPath : "";


### PR DESCRIPTION
I discovered this didn't work if the path to the file included a space...  Wrapping it in quotes fixed it for me.